### PR TITLE
Reverted bash package requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM frolvlad/alpine-oraclejdk8:slim
 ENV KOTLIN_VERSION=1.0.0-beta-3595 \
     KOTLIN_HOME=/usr/share/kotlin
 
-RUN apk add --update --virtual=build-dependencies wget ca-certificates && \
+RUN apk add --update bash && \
+    apk add --virtual=build-dependencies wget ca-certificates && \
     cd /tmp && \
     wget "https://github.com/JetBrains/kotlin/releases/download/build-${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip" && \
     unzip "kotlin-compiler-${KOTLIN_VERSION}.zip" && \


### PR DESCRIPTION
Unfortunatelly, `kotlinc` uses some bashisms, so we cannot use ash as a drop-in replacement.
